### PR TITLE
l10n_it_reverse_charge ADD "With additional supplier self invoice"

### DIFF
--- a/l10n_it_reverse_charge/README.rst
+++ b/l10n_it_reverse_charge/README.rst
@@ -14,6 +14,12 @@ dalle fatture fornitori intra UE ed extra UE mediante il reverse charge IVA.
 Inoltre è automatizzata la procedura di annullamento e riapertura della fattura
 fornitore.
 
+E' anche possibile utilizzare la modalità "con autofattura fornitore aggiuntiva".
+Questo tipicamente è usato per i fornitori extra UE, con lo scopo di mostrare,
+nel registro IVA acquisti, una fattura intestata alla propria azienda,
+che verrà poi totalmente riconciliata con l'autofattura attiva, sempre intestata alla
+propria azienda
+
 **NOTA**: al momento è gestito solo il metodo **Autofattura** e non quello
 **Integrazione IVA**.
 

--- a/l10n_it_reverse_charge/__openerp__.py
+++ b/l10n_it_reverse_charge/__openerp__.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Davide Corio
 # Copyright 2017 Alex Comba - Agile Business Group
+# Copyright 2017 Lorenzo Battistini - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': 'Reverse Charge IVA',
-    'version': '8.0.1.0.1',
+    'version': '8.0.2.0.0',
     'category': 'Localization/Italy',
     'summary': 'Reverse Charge for Italy',
     'author': 'Abstract, Agile Business Group,'
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
-    'website': 'http://www.abstract.it',
+    'website': 'https://www.odoo-italia.net',
     'depends': [
         'account',
         'account_invoice_entry_date',

--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -25,10 +25,13 @@ class AccountInvoice(models.Model):
     rc_self_invoice_id = fields.Many2one(
         comodel_name='account.invoice',
         string='RC Self Invoice',
-        copy=False)
+        copy=False, readonly=True)
     rc_purchase_invoice_id = fields.Many2one(
         comodel_name='account.invoice',
-        string='RC Purchase Invoice')
+        string='RC Purchase Invoice', copy=False, readonly=True)
+    rc_self_purchase_invoice_id = fields.Many2one(
+        comodel_name='account.invoice',
+        string='RC Self Purchase Invoice', copy=False, readonly=True)
 
     def rc_inv_line_vals(self, line):
         return {
@@ -80,10 +83,14 @@ class AccountInvoice(models.Model):
             'move_id': move.id,
             }
 
-    def rc_debit_line_vals(self, journal, move, rc_type):
+    def rc_debit_line_vals(self, move, amount=None):
+        if amount:
+            debit = amount
+        else:
+            debit = self.amount_tax
         return {
             'name': self.number,
-            'debit': self.amount_tax,
+            'debit': debit,
             'credit': 0.0,
             'account_id': self.get_inv_line_to_reconcile().account_id.id,
             'move_id': move.id,
@@ -117,131 +124,220 @@ class AccountInvoice(models.Model):
             'move_id': move.id,
             }
 
+    def reconcile_supplier_invoice(self):
+        rc_type = self.fiscal_position.rc_type_id
+        move_model = self.env['account.move']
+        move_line_model = self.env['account.move.line']
+        rc_payment_data = self.rc_payment_vals(rc_type)
+        rc_payment = move_model.create(rc_payment_data)
+        rc_invoice = self.rc_self_invoice_id
+
+        payment_credit_line_data = self.rc_payment_credit_line_vals(
+            rc_invoice, rc_payment)
+        payment_credit_line = move_line_model.create(payment_credit_line_data)
+        payment_debit_line_data = self.rc_debit_line_vals(
+            rc_payment, self.amount_total)
+        payment_debit_line = move_line_model.create(
+            payment_debit_line_data)
+
+        lines_to_rec = move_line_model.browse([
+            self.get_inv_line_to_reconcile().id,
+            payment_debit_line.id
+        ])
+        lines_to_rec.reconcile_partial()
+
+        rc_lines_to_rec = move_line_model.browse([
+            self.get_rc_inv_line_to_reconcile(rc_invoice).id,
+            payment_credit_line.id
+        ])
+        rc_lines_to_rec.reconcile_partial()
+
+    def partially_reconcile_supplier_invoice(self):
+        rc_type = self.fiscal_position.rc_type_id
+        move_model = self.env['account.move']
+        move_line_model = self.env['account.move.line']
+        rc_payment_data = self.rc_payment_vals(rc_type)
+        rc_payment = move_model.create(rc_payment_data)
+
+        payment_credit_line_data = self.rc_credit_line_vals(
+            rc_type.payment_journal_id, rc_payment)
+        move_line_model.create(payment_credit_line_data)
+
+        payment_debit_line_data = self.rc_debit_line_vals(rc_payment)
+        payment_debit_line = move_line_model.create(
+            payment_debit_line_data)
+        inv_lines_to_rec = move_line_model.browse(
+            [self.get_inv_line_to_reconcile().id,
+                payment_debit_line.id])
+        inv_lines_to_rec.reconcile_partial()
+        return rc_payment
+
+    def reconcile_rc_invoice(self, rc_payment):
+        rc_type = self.fiscal_position.rc_type_id
+        move_line_model = self.env['account.move.line']
+        rc_invoice = self.rc_self_invoice_id
+        rc_payment_credit_line_data = self.rc_payment_credit_line_vals(
+            rc_invoice, rc_payment)
+
+        rc_payment_line_to_reconcile = move_line_model.create(
+            rc_payment_credit_line_data)
+
+        rc_payment_debit_line_data = self.rc_payment_debit_line_vals(
+            rc_invoice, rc_type.payment_journal_id, rc_payment)
+        move_line_model.create(
+            rc_payment_debit_line_data)
+
+        rc_lines_to_rec = move_line_model.browse(
+            [self.get_rc_inv_line_to_reconcile(rc_invoice).id,
+                rc_payment_line_to_reconcile.id])
+        rc_lines_to_rec.reconcile_partial()
+
+    def generate_self_invoice(self):
+        rc_type = self.fiscal_position.rc_type_id
+        if not rc_type.payment_journal_id.default_credit_account_id:
+            raise UserError(
+                _('There is no default credit account defined \n'
+                  'on journal "%s".') % rc_type.payment_journal_id.name)
+        if rc_type.partner_type == 'other':
+            rc_partner = rc_type.partner_id
+        else:
+            rc_partner = self.partner_id
+        rc_account = rc_partner.property_account_receivable
+
+        rc_invoice_lines = []
+        for line in self.invoice_line:
+            if line.rc:
+                rc_invoice_line = self.rc_inv_line_vals(line)
+                line_tax = line.invoice_line_tax_id
+                tax_code_id = None
+                for tax_mapping in rc_type.tax_ids:
+                    if tax_mapping.purchase_tax_id == line_tax[0]:
+                        tax_code_id = tax_mapping.sale_tax_id.id
+                if not tax_code_id:
+                    raise UserError(_("Can't find tax mapping"))
+                if line_tax:
+                    rc_invoice_line['invoice_line_tax_id'] = [
+                        (6, False, [tax_code_id])]
+                rc_invoice_line[
+                    'account_id'] = rc_type.transitory_account_id.id
+                rc_invoice_lines.append([0, False, rc_invoice_line])
+
+        if rc_invoice_lines:
+            inv_vals = self.rc_inv_vals(
+                rc_partner, rc_account, rc_type, rc_invoice_lines)
+
+            # create or write the self invoice
+            if self.rc_self_invoice_id:
+                # this is needed when user takes back to draft supplier
+                # invoice, edit and validate again
+                rc_invoice = self.rc_self_invoice_id
+                rc_invoice.invoice_line.unlink()
+                rc_invoice.period_id = False
+                rc_invoice.write(inv_vals)
+                rc_invoice.button_reset_taxes()
+            else:
+                rc_invoice = self.create(inv_vals)
+                self.rc_self_invoice_id = rc_invoice.id
+            rc_invoice.signal_workflow('invoice_open')
+            if rc_type.with_supplier_self_invoice:
+                self.reconcile_supplier_invoice()
+            else:
+                rc_payment = self.partially_reconcile_supplier_invoice()
+                self.reconcile_rc_invoice(rc_payment)
+
+    def generate_supplier_self_invoice(self):
+        if not self.rc_self_purchase_invoice_id:
+            supplier_invoice = self.copy()
+        else:
+            supplier_invoice_vals = self.copy_data()
+            supplier_invoice = self.rc_self_purchase_invoice_id
+            supplier_invoice.invoice_line.unlink()
+            supplier_invoice.write(supplier_invoice_vals[0])
+        rc_type = self.fiscal_position.rc_type_id
+        supplier_invoice.partner_id = rc_type.partner_id.id
+        if not len(rc_type.tax_ids) == 1:
+            raise UserError(_(
+                "Can't find 1 tax mapping for %s" % rc_type.name))
+        for inv_line in supplier_invoice.invoice_line:
+            inv_line.invoice_line_tax_id = [
+                (6, 0, [rc_type.tax_ids[0].purchase_tax_id.id])]
+        self.rc_self_purchase_invoice_id = supplier_invoice.id
+        # temporary disabling self invoice automations
+        supplier_invoice.fiscal_position = None
+        supplier_invoice.button_reset_taxes()
+        supplier_invoice.check_total = supplier_invoice.amount_total
+        supplier_invoice.signal_workflow('invoice_open')
+        supplier_invoice.fiscal_position = self.fiscal_position.id
+
     @api.multi
     def invoice_validate(self):
         self.ensure_one()
         res = super(AccountInvoice, self).invoice_validate()
-
-        invoice_model = self.env['account.invoice']
-        move_model = self.env['account.move']
-        move_line_model = self.env['account.move.line']
-
         fp = self.fiscal_position
         rc_type = fp and fp.rc_type_id
         if rc_type and rc_type.method == 'selfinvoice':
-            if not rc_type.payment_journal_id.default_credit_account_id:
-                raise UserError(
-                    _('There is no default credit account defined \n'
-                      'on journal "%s".') % rc_type.payment_journal_id.name)
-            if rc_type.partner_type == 'other':
-                rc_partner = rc_type.partner_id
+            if not rc_type.with_supplier_self_invoice:
+                self.generate_self_invoice()
             else:
-                rc_partner = self.partner_id
-            rc_account = rc_partner.property_account_receivable
-
-            rc_invoice_lines = []
-            for line in self.invoice_line:
-                if line.rc:
-                    rc_invoice_line = self.rc_inv_line_vals(line)
-                    line_tax = line.invoice_line_tax_id
-                    for tax_mapping in rc_type.tax_ids:
-                        if tax_mapping.purchase_tax_id == line_tax[0]:
-                            tax_code_id = tax_mapping.sale_tax_id.id
-                    if line_tax:
-                        rc_invoice_line['invoice_line_tax_id'] = [
-                            (6, False, [tax_code_id])]
-                    rc_invoice_line[
-                        'account_id'] = rc_type.transitory_account_id.id
-                    rc_invoice_lines.append([0, False, rc_invoice_line])
-
-            if rc_invoice_lines:
-                inv_vals = self.rc_inv_vals(
-                    rc_partner, rc_account, rc_type, rc_invoice_lines)
-
-                # create or write the self invoice
-                if self.rc_self_invoice_id:
-                    rc_invoice = self.rc_self_invoice_id
-                    rc_invoice.invoice_line.unlink()
-                    rc_invoice.period_id = False
-                    rc_invoice.write(inv_vals)
-                    rc_invoice.button_reset_taxes()
-                else:
-                    rc_invoice = invoice_model.create(inv_vals)
-                    self.rc_self_invoice_id = rc_invoice.id
-                rc_invoice.signal_workflow('invoice_open')
-
-                # partially reconcile supplier invoice
-                rc_payment_data = self.rc_payment_vals(rc_type)
-                rc_payment = move_model.create(rc_payment_data)
-
-                payment_credit_line_data = self.rc_credit_line_vals(
-                    rc_type.payment_journal_id, rc_payment)
-                move_line_model.create(payment_credit_line_data)
-
-                payment_debit_line_data = self.rc_debit_line_vals(
-                    rc_type.payment_journal_id, rc_payment, rc_type)
-                payment_debit_line = move_line_model.create(
-                    payment_debit_line_data)
-                inv_lines_to_rec = move_line_model.browse(
-                    [self.get_inv_line_to_reconcile().id,
-                        payment_debit_line.id])
-                inv_lines_to_rec.reconcile_partial()
-
-                # reconcile rc invoice
-                rc_payment_credit_line_data = self.rc_payment_credit_line_vals(
-                    rc_invoice, rc_payment)
-
-                rc_payment_line_to_reconcile = move_line_model.create(
-                    rc_payment_credit_line_data)
-
-                rc_payment_debit_line_data = self.rc_payment_debit_line_vals(
-                    rc_invoice, rc_type.payment_journal_id, rc_payment)
-                move_line_model.create(
-                    rc_payment_debit_line_data)
-
-                rc_lines_to_rec = move_line_model.browse(
-                    [self.get_rc_inv_line_to_reconcile(rc_invoice).id,
-                        rc_payment_line_to_reconcile.id])
-                rc_lines_to_rec.reconcile_partial()
+                # See with_supplier_self_invoice field help
+                self.generate_supplier_self_invoice()
+                self.rc_self_purchase_invoice_id.generate_self_invoice()
         return res
+
+    def remove_rc_payment(self):
+        inv = self
+        if inv.payment_ids:
+            if len(inv.payment_ids) > 1:
+                raise UserError(
+                    _('There are more than one payment line.\n'
+                      'In that case account entries cannot be canceled'
+                      'automatically. Please proceed manually'))
+            payment_move = inv.payment_ids[0].move_id
+            # remove move reconcile related to the supplier invoice
+            move = inv.move_id
+            rec_partial_lines = move.mapped('line_id').filtered(
+                'reconcile_partial_id').mapped(
+                'reconcile_partial_id.line_partial_ids')
+            self.env['account.move.line']._remove_move_reconcile(
+                rec_partial_lines.ids)
+            # also remove full reconcile, in case of with_supplier_self_invoice
+            rec_partial_lines = move.mapped('line_id').filtered(
+                'reconcile_id').mapped('reconcile_id.line_id')
+            self.env['account.move.line']._remove_move_reconcile(
+                rec_partial_lines.ids)
+            # remove move reconcile related to the self invoice
+            move = inv.rc_self_invoice_id.move_id
+            rec_lines = move.mapped('line_id').filtered(
+                'reconcile_id').mapped('reconcile_id.line_id')
+            self.env['account.move.line']._remove_move_reconcile(
+                rec_lines.ids)
+            # cancel self invoice
+            self_invoice = self.browse(
+                inv.rc_self_invoice_id.id)
+            self_invoice.signal_workflow('invoice_cancel')
+            # invalidate and delete the payment move generated
+            # by the self invoice creation
+            payment_move.button_cancel()
+            payment_move.unlink()
 
     @api.multi
     def action_cancel(self):
-        invoice_model = self.env['account.invoice']
         for inv in self:
             rc_type = inv.fiscal_position.rc_type_id
             if (
-                    rc_type and
-                    rc_type.method == 'selfinvoice' and
-                    inv.rc_self_invoice_id
+                rc_type and
+                rc_type.method == 'selfinvoice' and
+                inv.rc_self_invoice_id
             ):
-                if len(inv.payment_ids) > 1:
-                    raise UserError(
-                        _('There are more than one payment line.\n'
-                          'In that case account entries cannot be canceled'
-                          'automatically. Please proceed manually'))
-                payment_move = inv.payment_ids[0].move_id
-                # remove move reconcile related to the supplier invoice
-                move = inv.move_id
-                rec_partial_lines = move.mapped('line_id').filtered(
-                    'reconcile_partial_id').mapped(
-                    'reconcile_partial_id.line_partial_ids')
-                self.env['account.move.line']._remove_move_reconcile(
-                    rec_partial_lines.ids)
-                # remove move reconcile related to the self invoice
-                move = inv.rc_self_invoice_id.move_id
-                rec_lines = move.mapped('line_id').filtered(
-                    'reconcile_id').mapped('reconcile_id.line_id')
-                self.env['account.move.line']._remove_move_reconcile(
-                    rec_lines.ids)
-                # cancel self invoice
-                self_invoice = invoice_model.browse(
-                    inv.rc_self_invoice_id.id)
-                self_invoice.signal_workflow('invoice_cancel')
-                # invalidate and delete the payment move generated
-                # by the self invoice creation
-                payment_move.button_cancel()
-                payment_move.unlink()
+                inv.remove_rc_payment()
+            elif (
+                rc_type and
+                rc_type.method == 'selfinvoice' and
+                inv.rc_self_purchase_invoice_id
+            ):
+                inv.rc_self_purchase_invoice_id.remove_rc_payment()
+                inv.rc_self_purchase_invoice_id.signal_workflow(
+                    'invoice_cancel')
         return super(AccountInvoice, self).action_cancel()
 
     @api.multi
@@ -253,4 +349,8 @@ class AccountInvoice(models.Model):
                 self_invoice = invoice_model.browse(
                     inv.rc_self_invoice_id.id)
                 self_invoice.action_cancel_draft()
+            if inv.rc_self_purchase_invoice_id:
+                self_purchase_invoice = invoice_model.browse(
+                    inv.rc_self_purchase_invoice_id.id)
+                self_purchase_invoice.action_cancel_draft()
         return True

--- a/l10n_it_reverse_charge/models/account_rc_type.py
+++ b/l10n_it_reverse_charge/models/account_rc_type.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Davide Corio
 # Copyright 2017 Alex Comba - Agile Business Group
+# Copyright 2017 Lorenzo Battistini - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import fields, models
+from openerp import fields, models, _, api
+from openerp.exceptions import ValidationError
 
 
 class AccountRCTypeTax(models.Model):
@@ -43,6 +45,13 @@ class AccountRCType(models.Model):
     partner_type = fields.Selection(
         (('supplier', 'Supplier'), ('other', 'Other')),
         string='Self Invoice Partner Type')
+    with_supplier_self_invoice = fields.Boolean(
+        "With additional supplier self invoice",
+        help="Flag this to enable the creation of an additional supplier self"
+             " invoice. This is tipically used for extraUE suppliers, "
+             "in order to show, in supplier register, an invoice to the "
+             "specified partner (tipically, my company), instead of the "
+             "extraUE partner")
     partner_id = fields.Many2one(
         'res.partner',
         string='Self Invoice Partner',
@@ -51,14 +60,14 @@ class AccountRCType(models.Model):
         'account.journal',
         string='Self Invoice Journal',
         help="Journal used on RC self invoices.")
+    supplier_journal_id = fields.Many2one(
+        'account.journal',
+        string='Supplier Self Invoice Journal',
+        help="Journal used on RC supplier self invoices.")
     payment_journal_id = fields.Many2one(
         'account.journal',
         string='Self Invoice Payment Journal',
         help="Journal used to pay RC self invoices.")
-    payment_partner_id = fields.Many2one(
-        'res.partner',
-        string='Self Invoice Payment Partner',
-        help="Partner used on RC self invoices.")
     transitory_account_id = fields.Many2one(
         'account.account',
         string='Self Invoice Transitory Account',
@@ -67,7 +76,18 @@ class AccountRCType(models.Model):
         'account.rc.type.tax',
         'rc_type_id',
         help="Example: 22_A_I_UE, 22_V_I_UE",
-        string='Self Invoice Tax Mapping')
+        string='Self Invoice Tax Mapping',
+        copy=False)
     description = fields.Text('Description')
-    invoice_text = fields.Text('Text on Invoice')
     self_invoice_text = fields.Text('Text in Self Invoice')
+
+    @api.multi
+    @api.constrains('with_supplier_self_invoice', 'tax_ids')
+    def _check_tax_ids(self):
+        for rctype in self:
+            if rctype.with_supplier_self_invoice and len(rctype.tax_ids) > 1:
+                raise ValidationError(_(
+                    'When "With additional supplier self invoice" you must set '
+                    'only one tax mapping line: only 1 tax per invoice is '
+                    'supported'
+                ))

--- a/l10n_it_reverse_charge/views/account_invoice_view.xml
+++ b/l10n_it_reverse_charge/views/account_invoice_view.xml
@@ -14,8 +14,9 @@
                 <xpath expr="//page[@string='Other Info']" position="inside">
                     <group string="Self Invoicing">
                         <field name="rc_self_invoice_id" readonly="True"
-                        domain="[('type', '=', 'out_invoice')]"
                         context="{'form_view_ref': 'account.invoice_form'}"/>
+                        <field name="rc_self_purchase_invoice_id" readonly="True"
+                        context="{'form_view_ref': 'account.supplier_invoice_form'}"/>
                     </group>
                 </xpath>
                 <xpath expr="//notebook/page[@string='Invoice']/field[@name='invoice_line']/tree/field[@name='price_subtotal']" position="after">
@@ -43,7 +44,6 @@
                 <xpath expr="//page[@string='Other Info']" position="inside">
                     <group string="Self Invoicing">
                         <field name="rc_purchase_invoice_id" readonly="True"
-                            domain="[('type', '=', 'in_invoice')]"
                             context="{'form_view_ref': 'account.supplier_invoice_form'}"/>
                     </group>
                 </xpath>

--- a/l10n_it_reverse_charge/views/account_rc_type_view.xml
+++ b/l10n_it_reverse_charge/views/account_rc_type_view.xml
@@ -23,6 +23,10 @@
                                 attrs="{
                                     'readonly': [('method', '!=', 'selfinvoice')],
                                     'required': [('method', '=', 'selfinvoice')]}"/>
+                            <field name="with_supplier_self_invoice"
+                                attrs="{'invisible': [
+                                '|',('partner_type', '!=', 'other'),
+                                ('method', '!=', 'selfinvoice')]}"/>
                             <field name="partner_id"
                                 attrs="{'readonly': [('method', '!=', 'selfinvoice')],
                                     'invisible': [('partner_type', '!=', 'other')],
@@ -31,6 +35,17 @@
                                 attrs="{
                                     'readonly': [('method', '!=', 'selfinvoice')],
                                     'required': [('method', '=', 'selfinvoice')]}"/>
+                            <field name="supplier_journal_id"
+                                attrs="{
+                                    'invisible': [
+                                    '|',('method', '!=', 'selfinvoice'),
+                                    '|',('partner_type', '!=', 'other'),
+                                        ('with_supplier_self_invoice', '!=', True)
+                                    ],
+                                    'required': [
+                                    ('method', '=', 'selfinvoice'),
+                                    ('partner_type', '=', 'other'),
+                                    ('with_supplier_self_invoice', '=', True)]}"/>
                             <field name="payment_journal_id"
                                 attrs="{
                                     'readonly': [('method', '!=', 'selfinvoice')],
@@ -48,9 +63,6 @@
                                     <field name="sale_tax_id" domain="[('parent_id','=',False)]"/>
                                 </tree>
                             </field>
-                        </group>
-                        <group string="Text on Invoice">
-                            <field name="invoice_text"/>
                         </group>
                         <group string="Text on Self Invoice">
                             <field name="self_invoice_text"


### PR DESCRIPTION
to enable the creation of an additional supplier self
invoice. This is tipically used for extraUE suppliers,
in order to show, in supplier register, an invoice to the
specified partner (tipically, my company), instead of the
extraUE partner

Also FIX
ValueError: "local variable 'tax_code_id' referenced before assignment" while evaluating
u'invoice_validate()'
when tax mapping not found